### PR TITLE
feat: Event Listener - fix updated naming

### DIFF
--- a/ios/CameraBridge.h
+++ b/ios/CameraBridge.h
@@ -18,6 +18,7 @@
 #import "Frame.h"
 #import "RCTBridge+runOnJS.h"
 #import "JSConsoleHelper.h"
+#import "RCTEventEmitter.h"
 
 #ifdef VISION_CAMERA_DISABLE_FRAME_PROCESSORS
 static bool VISION_CAMERA_ENABLE_FRAME_PROCESSORS = false;

--- a/ios/CameraEventEmitter.swift
+++ b/ios/CameraEventEmitter.swift
@@ -14,7 +14,7 @@ open class CameraEventEmitter: RCTEventEmitter {
 
   override init() {
     super.init()
-    RNEventEmitter.emitter = self
+		CameraEventEmitter.emitter = self
   }
 
   open override func supportedEvents() -> [String] {

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -232,8 +232,9 @@ extension CameraView {
           "shutterSpeed": device.exposureDuration.value,
           "exposureBias": device.exposureTargetBias
         ]
-        if !!change.newValue {
-          RNEventEmitter.emitter.sendEvent(withName: "onFinished", body: body)
+				if !Bool(change.newValue ?? false) {
+					ReactLogger.log(level: .info, message: "Sending event");
+					CameraEventEmitter.emitter.sendEvent(withName: "onChanged", body: body)
         }
       }
     }


### PR DESCRIPTION
## What
Fixed issues with incorrect references to new CameraEventEmitter.

## Changes

- Moved EventEmitter initialisation to the CameraView+AVCaptureSession class.

## Tested on
-  iPhone 11 Pro, iOS 14.3
