### PR TITLE
feature: (Exposure) Adds basic controls for ISO mode

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -324,7 +324,7 @@ PODS:
     - React
   - RNVectorIcons (8.1.0):
     - React-Core
-  - VisionCamera (2.15.2):
+  - VisionCamera (2.15.4):
     - React
     - React-callinvoker
     - React-Core
@@ -504,9 +504,9 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
-  VisionCamera: dd5fbdd9d38f12b485c3d84b7540ccd747cfeab8
+  VisionCamera: 5e976a74ca6f380bc75de09cd7d2e7effa1ecc9d
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 2ecfca9597c23d340a487bd11160e4bb54f55ecf
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.10.2

--- a/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
+++ b/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -517,7 +517,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/ios/CameraError.swift
+++ b/ios/CameraError.swift
@@ -79,6 +79,7 @@ enum DeviceError: String {
   case lowLightBoostNotSupported = "low-light-boost-not-supported"
   case focusNotSupported = "focus-not-supported"
   case notAvailableOnSimulator = "camera-not-available-on-simulator"
+	case customExposureNotSupported = "custom-exposure-not-supported"
 
   var code: String {
     return rawValue
@@ -102,6 +103,8 @@ enum DeviceError: String {
       return "The microphone was unavailable."
     case .notAvailableOnSimulator:
       return "The Camera is not available on the iOS Simulator!"
+		case .customExposureNotSupported:
+			return "The currently selected camera device does not support custom exposure!"
     }
   }
 }

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -285,17 +285,18 @@ extension CameraView {
 			invokeOnError(.session(.cameraNotReady))
 			return
 		}
+//		ReactLogger.log(level: .info, message: NSString(format: "%.2f", device.lensPosition) as String)
 		
 		if key == "exposureTargetOffset" {
-			ReactLogger.log(level: .info, message: "EV Target Offset Changed")
-			ReactLogger.log(level: .info, message: NSString(format: "%.2f", device.exposureTargetOffset) as String)
-			ReactLogger.log(level: .info, message: NSString(format: "%.2f", device.exposureTargetBias) as String)
+			let newExposureTargetOffset = changes[NSKeyValueChangeKey.newKey] as! Float
+//			ReactLogger.log(level: .info, message: "Offset is : \(newExposureTargetOffset)")
+			
 			let body: NSDictionary = [
-				"iso": device.iso,
+				"iso": device.iso, 
 				"aperture": device.lensAperture,
-				"ev": device.exposureDuration.value,
 				"evOffset": device.exposureTargetOffset,
 				"shutterSpeed": device.exposureDuration.seconds,
+				"lensPosition": device.lensPosition
 			]
 			CameraEventEmitter.emitter.sendEvent(withName: "onChanged", body: body)
 		}

--- a/ios/CameraView+Exposure.swift
+++ b/ios/CameraView+Exposure.swift
@@ -1,0 +1,22 @@
+//
+//  CameraView+Exposure.swift
+//  VisionCamera
+//
+//  Created by Fergal Eccles on 09/08/2023.
+//
+
+import Foundation
+
+extension CameraView {
+	func updateExposureSettings(iso: NSNumber, promise: Promise) {
+		withPromise(promise) {
+			guard let device = self.videoDeviceInput?.device else {
+				throw CameraError.session(SessionError.cameraNotReady)
+			}
+			
+			print("You made it!")
+			print(iso)
+			return nil
+		}
+	}
+}

--- a/ios/CameraView+Exposure.swift
+++ b/ios/CameraView+Exposure.swift
@@ -6,16 +6,42 @@
 //
 
 import Foundation
+import AVFoundation
 
 extension CameraView {
-	func updateExposureSettings(iso: NSNumber, promise: Promise) {
+	func updateExposureSettings(iso: NSString, promise: Promise) {
 		withPromise(promise) {
 			guard let device = self.videoDeviceInput?.device else {
 				throw CameraError.session(SessionError.cameraNotReady)
 			}
 			
-			print("You made it!")
-			print(iso)
+			guard let device = self.videoDeviceInput?.device else {
+				throw CameraError.session(SessionError.cameraNotReady)
+			}
+			if !device.isExposureModeSupported(.custom) {
+				throw CameraError.device(DeviceError.customExposureNotSupported)
+			}
+			
+			do {
+				try device.lockForConfiguration()
+				
+				if (iso == "auto") {
+					print("setting auto")
+					self.fixedISO = false
+					device.exposureMode = .continuousAutoExposure
+				} else {
+					print("setting fixed iso")
+					print(iso)
+					self.fixedISO = true
+					device.exposureMode = .custom
+					device.setExposureModeCustom(duration: AVCaptureDevice.currentExposureDuration, iso: Float(iso.doubleValue))
+				}
+				
+				device.unlockForConfiguration()
+			} catch {
+				throw CameraError.device(DeviceError.configureError)
+			}
+			
 			return nil
 		}
 	}

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -103,6 +103,9 @@ public final class CameraView: UIView {
   // CameraView+Zoom
   internal var pinchGestureRecognizer: UIPinchGestureRecognizer?
   internal var pinchScaleOffset: CGFloat = 1.0
+	//CameraView+Exposure
+	internal var fixedISO: Bool = false
+	internal var fixedExposureDuration: Bool = false
 
   internal let cameraQueue = CameraQueues.cameraQueue
   internal let videoQueue = CameraQueues.videoQueue

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -65,7 +65,7 @@ RCT_EXTERN_METHOD(resumeRecording:(nonnull NSNumber *)node resolve:(RCTPromiseRe
 RCT_EXTERN_METHOD(stopRecording:(nonnull NSNumber *)node resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(takePhoto:(nonnull NSNumber *)node options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber *)node point:(NSDictionary *)point resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
-RCT_EXTERN_METHOD(updateExposureSettings:(nonnull NSNumber *)node iso:(nonnull NSNumber *)iso resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(updateExposureSettings:(nonnull NSNumber *)node settings:(NSDictionary *)settings resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(getAvailableVideoCodecs:(nonnull NSNumber *)node fileType:(NSString *)fileType resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -65,6 +65,7 @@ RCT_EXTERN_METHOD(resumeRecording:(nonnull NSNumber *)node resolve:(RCTPromiseRe
 RCT_EXTERN_METHOD(stopRecording:(nonnull NSNumber *)node resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(takePhoto:(nonnull NSNumber *)node options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber *)node point:(NSDictionary *)point resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(updateExposureSettings:(nonnull NSNumber *)node iso:(nonnull NSNumber *)iso resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(getAvailableVideoCodecs:(nonnull NSNumber *)node fileType:(NSString *)fileType resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -83,6 +83,13 @@ final class CameraViewManager: RCTViewManager {
     let component = getCameraView(withTag: node)
     component.focus(point: CGPoint(x: x.doubleValue, y: y.doubleValue), promise: promise)
   }
+	
+	@objc
+	final func updateExposureSettings(_ node: NSNumber, iso: NSNumber, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+		let component = getCameraView(withTag: node)
+		let promise = Promise(resolver: resolve, rejecter: reject)
+		component.updateExposureSettings(iso: iso, promise: promise)
+	}
 
   @objc
   final func getAvailableVideoCodecs(_ node: NSNumber, fileType: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -85,9 +85,13 @@ final class CameraViewManager: RCTViewManager {
   }
 	
 	@objc
-	final func updateExposureSettings(_ node: NSNumber, iso: NSNumber, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+	final func updateExposureSettings(_ node: NSNumber, settings: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
 		let component = getCameraView(withTag: node)
 		let promise = Promise(resolver: resolve, rejecter: reject)
+		guard let iso = settings["iso"] as? NSString else {
+			promise.reject(error: .parameter(.invalid(unionName: "settings", receivedValue: settings.description)))
+			return
+		}
 		component.updateExposureSettings(iso: iso, promise: promise)
 	}
 

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -298,9 +298,9 @@ export class Camera extends React.PureComponent<CameraProps> {
    * @param iso
    * @returns
    */
-  public async updateExposureSettings(iso: Number): Promise<void> {
+  public async updateExposureSettings(settings: any): Promise<void> {
     try {
-      return CameraModule.updateExposureSettings(this.handle, iso);
+      return CameraModule.updateExposureSettings(this.handle, settings);
     } catch (e) {
       throw tryParseNativeCameraError(e);
     }

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -293,6 +293,18 @@ export class Camera extends React.PureComponent<CameraProps> {
       throw tryParseNativeCameraError(e);
     }
   }
+  /**
+   * Update the exposure settings to the specified values and lock changes.
+   * @param iso
+   * @returns
+   */
+  public async updateExposureSettings(iso: Number): Promise<void> {
+    try {
+      return CameraModule.updateExposureSettings(this.handle, iso);
+    } catch (e) {
+      throw tryParseNativeCameraError(e);
+    }
+  }
   //#endregion
 
   /**


### PR DESCRIPTION
## What
This PR adds an Exposure extension to VisionCamera. This WIP adds a method to update the ISO with a given value.

- Providing an ISO value will lock the ISO to the set value
- - *The exposure duration will also get locked to its' current value
- Setting the ISO to 'auto' will reset the exposure mode to 'continuousAutoExposure'

## Changes
- Added 'Exposure' extension
- Added function to Camera.tsx to trigger new extension method

## Tested on

* iPhone 13 Pro Max

