### PR TITLE
feat: ExposureLock - adds ability to lock the current exposure

### DIFF
--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -273,33 +273,5 @@ extension CameraView {
       }
     }
   }
-	
-	public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-
-		guard let key = keyPath, let changes = change else {
-				print("Not calling")
-				return
-		}
-		
-		guard let device: AVCaptureDevice = videoDeviceInput?.device else {
-			invokeOnError(.session(.cameraNotReady))
-			return
-		}
-//		ReactLogger.log(level: .info, message: NSString(format: "%.2f", device.lensPosition) as String)
-		
-		if key == "exposureTargetOffset" {
-			let newExposureTargetOffset = changes[NSKeyValueChangeKey.newKey] as! Float
-//			ReactLogger.log(level: .info, message: "Offset is : \(newExposureTargetOffset)")
-			
-			let body: NSDictionary = [
-				"iso": device.iso, 
-				"aperture": device.lensAperture,
-				"evOffset": device.exposureTargetOffset,
-				"shutterSpeed": device.exposureDuration.seconds,
-				"lensPosition": device.lensPosition
-			]
-			CameraEventEmitter.emitter.sendEvent(withName: "onChanged", body: body)
-		}
-	}
 }
 

--- a/ios/CameraView+Exposure.swift
+++ b/ios/CameraView+Exposure.swift
@@ -9,12 +9,8 @@ import Foundation
 import AVFoundation
 
 extension CameraView {
-	func updateExposureSettings(iso: NSString, promise: Promise) {
+	func updateExposureSettings(iso: NSString, exposureDuration: NSString, promise: Promise) {
 		withPromise(promise) {
-			guard let device = self.videoDeviceInput?.device else {
-				throw CameraError.session(SessionError.cameraNotReady)
-			}
-			
 			guard let device = self.videoDeviceInput?.device else {
 				throw CameraError.session(SessionError.cameraNotReady)
 			}
@@ -25,16 +21,20 @@ extension CameraView {
 			do {
 				try device.lockForConfiguration()
 				
-				if (iso == "auto") {
-					print("setting auto")
-					self.fixedISO = false
-					device.exposureMode = .continuousAutoExposure
-				} else {
-					print("setting fixed iso")
-					print(iso)
-					self.fixedISO = true
+				self.fixedISO = iso != "auto"
+				self.fixedExposureDuration = exposureDuration != "auto"
+				
+				if (self.fixedISO || self.fixedExposureDuration) {
 					device.exposureMode = .custom
-					device.setExposureModeCustom(duration: AVCaptureDevice.currentExposureDuration, iso: Float(iso.doubleValue))
+					
+					let durationValue = self.fixedExposureDuration ? CMTimeMake(value: 1, timescale: exposureDuration.intValue) : AVCaptureDevice.currentExposureDuration
+					let isoValue = self.fixedISO ? Float(iso.doubleValue) : AVCaptureDevice.currentISO
+					
+					device.setExposureModeCustom(duration: durationValue, iso: isoValue)
+					
+					// TODO: Set up function to auto-set values if either iso or exposure have been fixed
+				} else {
+					device.exposureMode = .continuousAutoExposure
 				}
 				
 				device.unlockForConfiguration()
@@ -43,6 +43,34 @@ extension CameraView {
 			}
 			
 			return nil
+		}
+	}
+	
+	public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+		guard let key = keyPath else {
+				print("Not calling")
+				return
+		}
+		
+		guard let device: AVCaptureDevice = videoDeviceInput?.device else {
+			invokeOnError(.session(.cameraNotReady))
+			return
+		}
+		
+		if key == "exposureTargetOffset" {
+			let body: NSDictionary = [
+				"iso": device.iso,
+				"aperture": device.lensAperture,
+				"evOffset": device.exposureTargetOffset,
+				"exposureDuration": device.exposureDuration.seconds,
+				"lensPosition": device.lensPosition,
+				"minExposureTargetBias": device.minExposureTargetBias,
+				"maxExposureTargetBias": device.maxExposureTargetBias,
+				"exposureTargetBias": device.exposureTargetBias
+			]
+			
+			CameraEventEmitter.emitter.sendEvent(withName: "onChanged", body: body)
 		}
 	}
 }

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -202,7 +202,8 @@ public final class CameraView: UIView {
     let shouldCheckActive = willReconfigure || changedProps.contains("isActive") || captureSession.isRunning != isActive
     let shouldUpdateTorch = willReconfigure || changedProps.contains("torch") || shouldCheckActive
     let shouldUpdateZoom = willReconfigure || changedProps.contains("zoom") || shouldCheckActive
-    let shouldUpdateVideoStabilization = willReconfigure || changedProps.contains("videoStabilizationMode")
+		let shouldUpdateExposure = willReconfigure || changedProps.contains("iso") || changedProps.contains("exposureDuration")
+		let shouldUpdateVideoStabilization = willReconfigure || changedProps.contains("videoStabilizationMode")
     let shouldUpdateOrientation = changedProps.contains("orientation")
 
     if shouldReconfigure ||

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -66,7 +66,7 @@ RCT_EXTERN_METHOD(stopRecording:(nonnull NSNumber *)node resolve:(RCTPromiseReso
 RCT_EXTERN_METHOD(takePhoto:(nonnull NSNumber *)node options:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber *)node point:(NSDictionary *)point resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 RCT_EXTERN_METHOD(updateExposureSettings:(nonnull NSNumber *)node settings:(NSDictionary *)settings resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
-
+RCT_EXTERN_METHOD(lockCurrentExposureSettings:(nonnull NSNumber *)node locked:(BOOL *)locked resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getAvailableVideoCodecs:(nonnull NSNumber *)node fileType:(NSString *)fileType resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 @end

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -88,11 +88,13 @@ final class CameraViewManager: RCTViewManager {
 	final func updateExposureSettings(_ node: NSNumber, settings: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
 		let component = getCameraView(withTag: node)
 		let promise = Promise(resolver: resolve, rejecter: reject)
-		guard let iso = settings["iso"] as? NSString else {
+
+		guard let iso = settings["iso"] as? NSString, let exposureDuration = settings["exposureDuration"] as? NSString else {
 			promise.reject(error: .parameter(.invalid(unionName: "settings", receivedValue: settings.description)))
 			return
 		}
-		component.updateExposureSettings(iso: iso, promise: promise)
+		
+		component.updateExposureSettings(iso: iso, exposureDuration: exposureDuration, promise: promise)
 	}
 
   @objc
@@ -143,8 +145,8 @@ final class CameraViewManager: RCTViewManager {
           "supportsRawCapture": false, // TODO: supportsRawCapture
           "supportsLowLightBoost": $0.isLowLightBoostSupported,
           "supportsFocus": $0.isFocusPointOfInterestSupported,
-          "formats": $0.formats.map { format -> [String: Any] in
-            format.toDictionary()
+					"formats": $0.formats.map { format -> [String: Any] in
+						format.toDictionary()
           },
         ]
       }

--- a/ios/CameraViewManager.swift
+++ b/ios/CameraViewManager.swift
@@ -96,6 +96,18 @@ final class CameraViewManager: RCTViewManager {
 		
 		component.updateExposureSettings(iso: iso, exposureDuration: exposureDuration, promise: promise)
 	}
+	
+	@objc
+	final func lockCurrentExposureSettings(_ node: NSNumber, locked: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+		let component = getCameraView(withTag: node)
+		let promise = Promise(resolver: resolve, rejecter: reject)
+		
+		guard let locked = locked as? Bool else {
+			promise.reject(error: .parameter(.invalid(unionName: "locked", receivedValue: locked.description)))
+		}
+		
+		component.lockCurrentExposureSettings(locked: locked, promise: promise)
+	}
 
   @objc
   final func getAvailableVideoCodecs(_ node: NSNumber, fileType: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {

--- a/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -43,6 +43,10 @@ extension AVCaptureDevice.Format {
         ]
       },
       "pixelFormat": CMFormatDescriptionGetMediaSubType(formatDescription).toString(),
+			// Convert exposureDuration values to milliseconds.
+			"minExposureDuration": CMTimeGetSeconds(minExposureDuration) * 1000,
+			"maxExposureDuration": CMTimeGetSeconds(maxExposureDuration) * 1000,
+			
     ]
 
     if #available(iOS 13.0, *) {

--- a/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
+++ b/ios/Extensions/AVCaptureDevice.Format+toDictionary.swift
@@ -46,7 +46,6 @@ extension AVCaptureDevice.Format {
 			// Convert exposureDuration values to milliseconds.
 			"minExposureDuration": CMTimeGetSeconds(minExposureDuration) * 1000,
 			"maxExposureDuration": CMTimeGetSeconds(maxExposureDuration) * 1000,
-			
     ]
 
     if #available(iOS 13.0, *) {

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -295,12 +295,26 @@ export class Camera extends React.PureComponent<CameraProps> {
   }
   /**
    * Update the exposure settings to the specified values and lock changes.
-   * @param iso
-   * @returns
+   * @param settings any The camera settings to set the CameraDevice to. This should include
+   * an ISO value and an exposureDuration value. Passing both props as type 'any' will
+   * reset the Camera device to continuous exposure updates.
+   * @returns Promise<void>
    */
   public async updateExposureSettings(settings: any): Promise<void> {
     try {
       return CameraModule.updateExposureSettings(this.handle, settings);
+    } catch (e) {
+      throw tryParseNativeCameraError(e);
+    }
+  }
+  /**
+   * Locks the CameraDevice's current exposure settings
+   * @param state
+   * @returns Promise<void>
+   */
+  public async lockCurrentExposureSettings(state: boolean): Promise<void> {
+    try {
+      return CameraModule.lockCurrentExposureSettings(this.handle, state);
     } catch (e) {
       throw tryParseNativeCameraError(e);
     }

--- a/src/CameraDevice.ts
+++ b/src/CameraDevice.ts
@@ -178,6 +178,14 @@ export interface CameraDeviceFormat {
    * The most common format is `420v`. Some formats (like `x420`) are not compatible with some frame processor plugins (e.g. MLKit)
    */
   pixelFormat: PixelFormat;
+  /**
+   * Specifies this formats' maximum exposure duration value in ms.
+   */
+  maxExposureDuration: number;
+  /**
+   * Specifies this formats' minimum exposure duration value in ms.
+   */
+  minExposureDuration: number;
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR adds a new method with an RCT bridge to allow the React app to 'lock' the current exposure settings.
 - The method takes one boolean parameter and conditionally locks or unlocks the device exposure.

## Changes
 - Adds the `updateExposureSettings` method to the Exposure extension.
 - Moves the module event emitter to Exposure extension.

## Tested on
 - iPhone 13 Pro (17.1.1)
